### PR TITLE
PURP-12380 - Handle required and default inputs configured in action.yml

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5316,14 +5316,19 @@ function parseRepo () {
 
 function setInputs(action){
   if (!action.inputs) {
+    core.info('No inputs defined in action.');
     return;
   }
 
   for (const i of Object.keys(action.inputs)) {
     const formattedInputName = `INPUT_${i.toUpperCase()}`;
 
-    if ((process.env[formattedInputName])||(!action.inputs[i].required && !action.inputs[i].default)) {
+    if ((process.env[formattedInputName])) {
+      core.info(`Input ${action.input[i]} already set`)
       // the input was provided, or not provided but not required or w/ default
+      return;
+    } else if (!action.inputs[i].required && !action.inputs[i].default) {
+      core.info(`Input ${action.inputs[i]} not required and has no default`)
       return;
     } else if (action.inputs[i].required && !action.inputs[i].default) {
       // input not provided, is required, and no default set
@@ -5331,6 +5336,7 @@ function setInputs(action){
     }
 
     // input not provided so use the default
+    core.info(`Input ${action.inputs[i]} not set.  Using default ${action.inputs[i].default}`)
     process.env[formattedInputName] = action.inputs[i].default
   }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -5320,6 +5320,8 @@ function setInputs(action){
     return;
   }
 
+  core.info(`The configured inputs are ${Object.keys(action.inputs)}`)
+
   for (const i of Object.keys(action.inputs)) {
     const formattedInputName = `INPUT_${i.toUpperCase()}`;
 
@@ -5336,7 +5338,7 @@ function setInputs(action){
     }
 
     // input not provided so use the default
-    core.info(`Input ${i} not set.  Using default ${action.inputs[i].default}`)
+    core.info(`Input ${i} not set.  Using default '${action.inputs[i].default}'`)
     process.env[formattedInputName] = action.inputs[i].default
   }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -5324,11 +5324,11 @@ function setInputs(action){
     const formattedInputName = `INPUT_${i.toUpperCase()}`;
 
     if ((process.env[formattedInputName])) {
-      core.info(`Input ${action.input[i]} already set`)
+      core.info(`Input ${i} already set`)
       // the input was provided, or not provided but not required or w/ default
       return;
     } else if (!action.inputs[i].required && !action.inputs[i].default) {
-      core.info(`Input ${action.inputs[i]} not required and has no default`)
+      core.info(`Input ${i} not required and has no default`)
       return;
     } else if (action.inputs[i].required && !action.inputs[i].default) {
       // input not provided, is required, and no default set
@@ -5336,7 +5336,7 @@ function setInputs(action){
     }
 
     // input not provided so use the default
-    core.info(`Input ${action.inputs[i]} not set.  Using default ${action.inputs[i].default}`)
+    core.info(`Input ${i} not set.  Using default ${action.inputs[i].default}`)
     process.env[formattedInputName] = action.inputs[i].default
   }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -5251,7 +5251,9 @@ const WORKING_DIR = './.private-action'
 
 async function run () {
 
-  core.info(JSON.stringify(process.env, null, 2));
+  const inputs = Object.keys(process.env).filter(k=>k.startsWith('INPUT_'))
+
+  core.info(JSON.stringify(inputs, null, 2));
 
   const { repo, sha } = parseRepo()
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -5327,11 +5327,11 @@ function setInputs(action){
 
     if ((process.env[formattedInputName])) {
       core.info(`Input ${i} already set`)
-      // the input was provided, or not provided but not required or w/ default
-      return;
+      // the input was provided
+      break;
     } else if (!action.inputs[i].required && !action.inputs[i].default) {
       core.info(`Input ${i} not required and has no default`)
-      return;
+      break;
     } else if (action.inputs[i].required && !action.inputs[i].default) {
       // input not provided, is required, and no default set
       core.error(`Input ${i} required but not provided and no default is set`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -5284,21 +5284,9 @@ async function run () {
 
   core.endGroup('Cloning private action')
   
-  core.startGroup('Input Setting')
-  function getVals(label){
-    const keys = Object.keys(process.env)
-    .filter(key => key.startsWith('INPUT_'))
-    .reduce((obj, key) => {
-      obj[key] = process.env[key];
-      return obj;
-    }, {});
-
-    console.log(label, JSON.stringify(keys, null, 2))
-  }
-  getVals('***BEFORE***')
+  core.startGroup('Input Validation')
   setInputs(action)
-  getVals('***AFTER***')
-  core.endGroup('Input Setting')
+  core.endGroup('Input Validation')
 
   core.info(`Starting private action ${action.name}`)
   core.startGroup(`${action.name}`)

--- a/dist/index.js
+++ b/dist/index.js
@@ -5314,22 +5314,18 @@ function setInputs(action){
     const formattedInputName = `INPUT_${i.toUpperCase()}`;
 
     if ((process.env[formattedInputName])) {
-      core.info(`Input ${i} already set`)
-      // the input was provided
+      core.info(`Input ${i} already set`);
       continue;
     } else if (!action.inputs[i].required && !action.inputs[i].default) {
-      core.info(`Input ${i} not required and has no default`)
+      core.info(`Input ${i} not required and has no default`);
       continue;
     } else if (action.inputs[i].required && !action.inputs[i].default) {
-      // input not provided, is required, and no default set
       core.error(`Input ${i} required but not provided and no default is set`);
     }
 
-    // input not provided so use the default
     core.info(`Input ${i} not set.  Using default '${action.inputs[i].default}'`)
     process.env[formattedInputName] = action.inputs[i].default
   }
-
 }
 
 run().then(() => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -5250,11 +5250,6 @@ const GITHUB_REPO = core.getInput('repo-name', { required: true })
 const WORKING_DIR = './.private-action'
 
 async function run () {
-
-  const inputs = Object.keys(process.env).filter(k=>k.startsWith('INPUT_'))
-
-  core.info(JSON.stringify(inputs, null, 2));
-
   const { repo, sha } = parseRepo()
 
   core.info('Masking token just in case')
@@ -5282,11 +5277,13 @@ async function run () {
   core.info('Reading action.yml')
   const actionFile = readFileSync(`${WORKING_DIR}/action.yml`, 'utf8')
   const action = parse(actionFile)
-
+  
   if (!(action && action.name && action.runs && action.runs.main)) {
     throw new Error('Malformed action.yml found')
   }
 
+  const inputs = setInputs(action)
+  
   core.endGroup('Cloning private action')
 
   core.info(`Starting private action ${action.name}`)
@@ -5301,6 +5298,28 @@ function parseRepo () {
     repo: repoArr[0],
     sha: repoArr[1]
   }
+}
+
+function setInputs(action){
+  if (!action.inputs) {
+    return;
+  }
+
+  for (const i of Object.keys(action.inputs)) {
+    const formattedInputName = `INPUT_${i.toUpperCase()}`;
+
+    if ((process.env[formattedInputName])||(!action.inputs[i].required && !action.inputs[i].default)) {
+      // the input was provided, or not provided but not required or w/ default
+      return;
+    } else if (action.inputs[i].required && !action.inputs[i].default) {
+      // input not provided, is required, and no default set
+      core.error(`Input ${i} required but not provided and no default is set`);
+    }
+
+    // input not provided so use the default
+    process.env[formattedInputName] = action.inputs[i].default
+  }
+
 }
 
 run().then(() => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -5250,6 +5250,9 @@ const GITHUB_REPO = core.getInput('repo-name', { required: true })
 const WORKING_DIR = './.private-action'
 
 async function run () {
+
+  core.info(JSON.stringify(process.env, null, 2));
+
   const { repo, sha } = parseRepo()
 
   core.info('Masking token just in case')

--- a/dist/index.js
+++ b/dist/index.js
@@ -5287,7 +5287,7 @@ async function run () {
   core.startGroup('Input Setting')
   function getVals(label){
     const keys = Object.keys(process.env)
-    .filter(key => allowed.includes(key))
+    .filter(key => key.startsWith('INPUT_'))
     .reduce((obj, key) => {
       obj[key] = process.env[key];
       return obj;

--- a/dist/index.js
+++ b/dist/index.js
@@ -5282,9 +5282,23 @@ async function run () {
     throw new Error('Malformed action.yml found')
   }
 
-  const inputs = setInputs(action)
-  
   core.endGroup('Cloning private action')
+  
+  core.startGroup('Input Setting')
+  function getVals(label){
+    const keys = Object.keys(process.env)
+    .filter(key => allowed.includes(key))
+    .reduce((obj, key) => {
+      obj[key] = process.env[key];
+      return obj;
+    }, {});
+
+    console.log(label, JSON.stringify(keys, null, 2))
+  }
+  getVals('***BEFORE***')
+  setInputs(action)
+  getVals('***AFTER***')
+  core.endGroup('Input Setting')
 
   core.info(`Starting private action ${action.name}`)
   core.startGroup(`${action.name}`)

--- a/dist/index.js
+++ b/dist/index.js
@@ -5328,10 +5328,10 @@ function setInputs(action){
     if ((process.env[formattedInputName])) {
       core.info(`Input ${i} already set`)
       // the input was provided
-      break;
+      continue;
     } else if (!action.inputs[i].required && !action.inputs[i].default) {
       core.info(`Input ${i} not required and has no default`)
-      break;
+      continue;
     } else if (action.inputs[i].required && !action.inputs[i].default) {
       // input not provided, is required, and no default set
       core.error(`Input ${i} required but not provided and no default is set`);

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,9 @@ const GITHUB_REPO = core.getInput('repo-name', { required: true })
 const WORKING_DIR = './.private-action'
 
 async function run () {
+
+  core.info(JSON.stringify(process.env, null, 2));
+
   const { repo, sha } = parseRepo()
 
   core.info('Masking token just in case')

--- a/src/index.js
+++ b/src/index.js
@@ -41,9 +41,23 @@ async function run () {
     throw new Error('Malformed action.yml found')
   }
 
-  const inputs = setInputs(action)
-  
   core.endGroup('Cloning private action')
+  
+  core.startGroup('Input Setting')
+  function getVals(label){
+    const keys = Object.keys(process.env)
+    .filter(key => allowed.includes(key))
+    .reduce((obj, key) => {
+      obj[key] = process.env[key];
+      return obj;
+    }, {});
+
+    console.log(label, JSON.stringify(keys, null, 2))
+  }
+  getVals('***BEFORE***')
+  setInputs(action)
+  getVals('***AFTER***')
+  core.endGroup('Input Setting')
 
   core.info(`Starting private action ${action.name}`)
   core.startGroup(`${action.name}`)

--- a/src/index.js
+++ b/src/index.js
@@ -73,22 +73,18 @@ function setInputs(action){
     const formattedInputName = `INPUT_${i.toUpperCase()}`;
 
     if ((process.env[formattedInputName])) {
-      core.info(`Input ${i} already set`)
-      // the input was provided
+      core.info(`Input ${i} already set`);
       continue;
     } else if (!action.inputs[i].required && !action.inputs[i].default) {
-      core.info(`Input ${i} not required and has no default`)
+      core.info(`Input ${i} not required and has no default`);
       continue;
     } else if (action.inputs[i].required && !action.inputs[i].default) {
-      // input not provided, is required, and no default set
       core.error(`Input ${i} required but not provided and no default is set`);
     }
 
-    // input not provided so use the default
     core.info(`Input ${i} not set.  Using default '${action.inputs[i].default}'`)
     process.env[formattedInputName] = action.inputs[i].default
   }
-
 }
 
 run().then(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,9 @@ const WORKING_DIR = './.private-action'
 
 async function run () {
 
-  core.info(JSON.stringify(process.env, null, 2));
+  const inputs = Object.keys(process.env).filter(k=>k.startsWith('INPUT_'))
+
+  core.info(JSON.stringify(inputs, null, 2));
 
   const { repo, sha } = parseRepo()
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,6 @@ const GITHUB_REPO = core.getInput('repo-name', { required: true })
 const WORKING_DIR = './.private-action'
 
 async function run () {
-
-  const inputs = Object.keys(process.env).filter(k=>k.startsWith('INPUT_'))
-
-  core.info(JSON.stringify(inputs, null, 2));
-
   const { repo, sha } = parseRepo()
 
   core.info('Masking token just in case')
@@ -41,11 +36,13 @@ async function run () {
   core.info('Reading action.yml')
   const actionFile = readFileSync(`${WORKING_DIR}/action.yml`, 'utf8')
   const action = parse(actionFile)
-
+  
   if (!(action && action.name && action.runs && action.runs.main)) {
     throw new Error('Malformed action.yml found')
   }
 
+  const inputs = setInputs(action)
+  
   core.endGroup('Cloning private action')
 
   core.info(`Starting private action ${action.name}`)
@@ -60,6 +57,28 @@ function parseRepo () {
     repo: repoArr[0],
     sha: repoArr[1]
   }
+}
+
+function setInputs(action){
+  if (!action.inputs) {
+    return;
+  }
+
+  for (const i of Object.keys(action.inputs)) {
+    const formattedInputName = `INPUT_${i.toUpperCase()}`;
+
+    if ((process.env[formattedInputName])||(!action.inputs[i].required && !action.inputs[i].default)) {
+      // the input was provided, or not provided but not required or w/ default
+      return;
+    } else if (action.inputs[i].required && !action.inputs[i].default) {
+      // input not provided, is required, and no default set
+      core.error(`Input ${i} required but not provided and no default is set`);
+    }
+
+    // input not provided so use the default
+    process.env[formattedInputName] = action.inputs[i].default
+  }
+
 }
 
 run().then(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -75,14 +75,19 @@ function parseRepo () {
 
 function setInputs(action){
   if (!action.inputs) {
+    core.info('No inputs defined in action.');
     return;
   }
 
   for (const i of Object.keys(action.inputs)) {
     const formattedInputName = `INPUT_${i.toUpperCase()}`;
 
-    if ((process.env[formattedInputName])||(!action.inputs[i].required && !action.inputs[i].default)) {
+    if ((process.env[formattedInputName])) {
+      core.info(`Input ${action.input[i]} already set`)
       // the input was provided, or not provided but not required or w/ default
+      return;
+    } else if (!action.inputs[i].required && !action.inputs[i].default) {
+      core.info(`Input ${action.inputs[i]} not required and has no default`)
       return;
     } else if (action.inputs[i].required && !action.inputs[i].default) {
       // input not provided, is required, and no default set
@@ -90,6 +95,7 @@ function setInputs(action){
     }
 
     // input not provided so use the default
+    core.info(`Input ${action.inputs[i]} not set.  Using default ${action.inputs[i].default}`)
     process.env[formattedInputName] = action.inputs[i].default
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,8 @@ function setInputs(action){
     return;
   }
 
+  core.info(`The configured inputs are ${Object.keys(action.inputs)}`)
+
   for (const i of Object.keys(action.inputs)) {
     const formattedInputName = `INPUT_${i.toUpperCase()}`;
 
@@ -95,7 +97,7 @@ function setInputs(action){
     }
 
     // input not provided so use the default
-    core.info(`Input ${i} not set.  Using default ${action.inputs[i].default}`)
+    core.info(`Input ${i} not set.  Using default '${action.inputs[i].default}'`)
     process.env[formattedInputName] = action.inputs[i].default
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -43,21 +43,9 @@ async function run () {
 
   core.endGroup('Cloning private action')
   
-  core.startGroup('Input Setting')
-  function getVals(label){
-    const keys = Object.keys(process.env)
-    .filter(key => key.startsWith('INPUT_'))
-    .reduce((obj, key) => {
-      obj[key] = process.env[key];
-      return obj;
-    }, {});
-
-    console.log(label, JSON.stringify(keys, null, 2))
-  }
-  getVals('***BEFORE***')
+  core.startGroup('Input Validation')
   setInputs(action)
-  getVals('***AFTER***')
-  core.endGroup('Input Setting')
+  core.endGroup('Input Validation')
 
   core.info(`Starting private action ${action.name}`)
   core.startGroup(`${action.name}`)

--- a/src/index.js
+++ b/src/index.js
@@ -87,10 +87,10 @@ function setInputs(action){
     if ((process.env[formattedInputName])) {
       core.info(`Input ${i} already set`)
       // the input was provided
-      break;
+      continue;
     } else if (!action.inputs[i].required && !action.inputs[i].default) {
       core.info(`Input ${i} not required and has no default`)
-      break;
+      continue;
     } else if (action.inputs[i].required && !action.inputs[i].default) {
       // input not provided, is required, and no default set
       core.error(`Input ${i} required but not provided and no default is set`);

--- a/src/index.js
+++ b/src/index.js
@@ -83,11 +83,11 @@ function setInputs(action){
     const formattedInputName = `INPUT_${i.toUpperCase()}`;
 
     if ((process.env[formattedInputName])) {
-      core.info(`Input ${action.input[i]} already set`)
+      core.info(`Input ${i} already set`)
       // the input was provided, or not provided but not required or w/ default
       return;
     } else if (!action.inputs[i].required && !action.inputs[i].default) {
-      core.info(`Input ${action.inputs[i]} not required and has no default`)
+      core.info(`Input ${i} not required and has no default`)
       return;
     } else if (action.inputs[i].required && !action.inputs[i].default) {
       // input not provided, is required, and no default set
@@ -95,7 +95,7 @@ function setInputs(action){
     }
 
     // input not provided so use the default
-    core.info(`Input ${action.inputs[i]} not set.  Using default ${action.inputs[i].default}`)
+    core.info(`Input ${i} not set.  Using default ${action.inputs[i].default}`)
     process.env[formattedInputName] = action.inputs[i].default
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -86,11 +86,11 @@ function setInputs(action){
 
     if ((process.env[formattedInputName])) {
       core.info(`Input ${i} already set`)
-      // the input was provided, or not provided but not required or w/ default
-      return;
+      // the input was provided
+      break;
     } else if (!action.inputs[i].required && !action.inputs[i].default) {
       core.info(`Input ${i} not required and has no default`)
-      return;
+      break;
     } else if (action.inputs[i].required && !action.inputs[i].default) {
       // input not provided, is required, and no default set
       core.error(`Input ${i} required but not provided and no default is set`);

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ async function run () {
   core.startGroup('Input Setting')
   function getVals(label){
     const keys = Object.keys(process.env)
-    .filter(key => allowed.includes(key))
+    .filter(key => key.startsWith('INPUT_'))
     .reduce((obj, key) => {
       obj[key] = process.env[key];
       return obj;


### PR DESCRIPTION
This fix now reads the action.yml for a private action and compares the inputs in the configuration versus the inputs available at runtime.  If an input is found in configuration that doesn't exist at runtime, it will fail if it's required and without a default value, or create it if a default value exists.  

This was tested here: https://github.com/InVisionApp/studio-design-system/commit/38a5ab6b027718c73af823dea739cbb3800b8568/checks?check_suite_id=349256191#step:10:18