### PR TITLE
Updated inputs to include pal- prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ This action loads and executes a private Action. This allows private actions to 
 
 ## **Inputs**
 
-### **`repo-token`**
+### **`pal-repo-token`**
 
 **Required** An access token with the [repo](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) scope to the repository containing the action. **This should be stored as a [repo secret](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)**.
 
-### **`repo-name`**
+### **`pal-repo-name`**
 
 **Required** The repository containing the action. A ref can also be appended to specify an exact commit of the action (SHA, tag, or branch). Must be in the format of `{owner}/{repo}` or `{owner}/{repo}@{sha}`.
 
-### **`action-directory`**
+### **`pal-action-directory`**
 
 **Optional** Directory containing the `action.yml` that you would like to execute in repo. If omitted, the root directory is assumed to be the location of `action.yml`.
 
@@ -30,14 +30,14 @@ This action loads and executes a private Action. This allows private actions to 
 
 ## **Examples**
 
-## Example usage w/ action-directory
+## Example usage w/ pal-action-directory
 
 ```yaml
 - uses: invisionapp/private-action-loader@v1
   with:
-    repo-token: ${{ secrets.REPO_TOKEN }}
-    repo-name: some-org/super-secret-action
-    action-directory: src/super-secret-nested-action
+    pal-repo-token: ${{ secrets.REPO_TOKEN }}
+    pal-repo-name: some-org/super-secret-action
+    pal-action-directory: src/super-secret-nested-action
 ```
 
 ## Example usage w/ additional parameters
@@ -45,8 +45,8 @@ This action loads and executes a private Action. This allows private actions to 
 ```yaml
 - uses: invisionapp/private-action-loader@v1
   with:
-    repo-token: ${{ secrets.REPO_TOKEN }}
-    repo-name: some-org/super-secret-action
+    pal-repo-token: ${{ secrets.REPO_TOKEN }}
+    pal-repo-name: some-org/super-secret-action
     # the following input gets passed to the private action
     input-used-by-other-action: this will be passed to super-secret-action
 ```
@@ -56,8 +56,8 @@ This action loads and executes a private Action. This allows private actions to 
 ```yaml
 - uses: invisionapp/private-action-loader@v1
   with:
-    repo-token: ${{ secrets.REPO_TOKEN }}
-    repo-name: some-org/super-secret-action
+    pal-repo-token: ${{ secrets.REPO_TOKEN }}
+    pal-repo-name: some-org/super-secret-action
 ```
 
 ## Example usage w/ SHA
@@ -65,8 +65,8 @@ This action loads and executes a private Action. This allows private actions to 
 ```yaml
 - uses: invisionapp/private-action-loader@v1
   with:
-    repo-token: ${{ secrets.REPO_TOKEN }}
-    repo-name: some-org/super-secret-action@b8a83a0
+    pal-repo-token: ${{ secrets.REPO_TOKEN }}
+    pal-repo-name: some-org/super-secret-action@b8a83a0
 ```
 
 ## Example usage w/ Branch
@@ -74,8 +74,8 @@ This action loads and executes a private Action. This allows private actions to 
 ```yaml
 - uses: invisionapp/private-action-loader@v1
   with:
-    repo-token: ${{ secrets.REPO_TOKEN }}
-    repo-name: some-org/super-secret-action@master
+    pal-repo-token: ${{ secrets.REPO_TOKEN }}
+    pal-repo-name: some-org/super-secret-action@master
 ```
 
 ## Example usage w/ Tag
@@ -83,8 +83,8 @@ This action loads and executes a private Action. This allows private actions to 
 ```yaml
 - uses: invisionapp/private-action-loader@v1
   with:
-    repo-token: ${{ secrets.REPO_TOKEN }}
-    repo-name: some-org/super-secret-action@v1
+    pal-repo-token: ${{ secrets.REPO_TOKEN }}
+    pal-repo-name: some-org/super-secret-action@v1
 ```
 
 ## Example usage w/ Output
@@ -93,8 +93,8 @@ This action loads and executes a private Action. This allows private actions to 
 - uses: invisionapp/private-action-loader@v1
   id: output_example
   with:
-    repo-token: ${{ secrets.REPO_TOKEN }}
-    repo-name: some-org/super-secret-action@v1
+    pal-repo-token: ${{ secrets.REPO_TOKEN }}
+    pal-repo-name: some-org/super-secret-action@v1
 - name: Get the previous output
   run: echo "The previous output was ${{ steps.output_example.outputs.<name of output> }}"
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,13 +1,13 @@
 name: Private Action Loader
 description: Enables private Actions to be easily reused across repositories.
 inputs:
-  repo-token:
+  pal-repo-token:
     description: 'Access token with read access to the repo containing action'
     required: true
-  repo-name:
+  pal-repo-name:
     description: 'The organization/user and repo where action is stored, with support for @ref'
     required: true
-  action-directory:
+  pal-action-directory:
     description: 'The optional path to directory containing action.  Useful when multiple private actions are stored in the same repo'
     required: false
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -4264,9 +4264,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 var core = __importStar(__webpack_require__(470));
 var action_1 = __webpack_require__(960);
-var token = core.getInput('repo-token', { required: true });
-var repoName = core.getInput('repo-name', { required: true });
-var actionDirectory = core.getInput('action-directory', { required: false });
+var token = core.getInput('pal-repo-token', { required: true });
+var repoName = core.getInput('pal-repo-name', { required: true });
+var actionDirectory = core.getInput('pal-action-directory', { required: false });
 var workDirectory = './.private-action';
 action_1.runAction({
     token: token,

--- a/src/__tests__/action.spec.ts
+++ b/src/__tests__/action.spec.ts
@@ -107,7 +107,7 @@ describe('runAction', () => {
     expect(checkingOutInfoCalled).toBe(false);
   });
 
-  test('action loaded and executed from expected location when action-directory not specified', async () => {
+  test('action loaded and executed from expected location when pal-action-directory not specified', async () => {
     const expectedPath = `${workDirectory}/action.yml`;
     await runAction({
       token,
@@ -119,7 +119,7 @@ describe('runAction', () => {
     expect(exec.exec).toHaveBeenLastCalledWith(`node ${workDirectory}/${mainLocation}`);
   });
 
-  test('action loaded from expected location when action-directory specified', async () => {
+  test('action loaded from expected location when pal-action-directory specified', async () => {
     const expectedPath = `${workDirectory}/${actionDirectory}/action.yml`;
     await runAction({
       token,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import * as core from '@actions/core';
 import { runAction } from './action';
 
-const token = core.getInput('repo-token', { required: true });
-const repoName = core.getInput('repo-name', { required: true });
-const actionDirectory = core.getInput('action-directory', { required: false });
+const token = core.getInput('pal-repo-token', { required: true });
+const repoName = core.getInput('pal-repo-name', { required: true });
+const actionDirectory = core.getInput('pal-action-directory', { required: false });
 const workDirectory = './.private-action';
 
 runAction({


### PR DESCRIPTION
Updated input names to include pal-prefix because `repo-name` and `repo-token` are common input names.