### PR TITLE
patch: remove group that wrapped private action

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12158,11 +12158,9 @@ function runAction(opts) {
                     setInputs(action);
                     core.endGroup();
                     core.info("Starting private action " + action.name);
-                    core.startGroup("" + action.name);
                     return [4 /*yield*/, exec.exec("node " + path_1.join(actionPath, action.runs.main))];
                 case 5:
                     _b.sent();
-                    core.endGroup();
                     core.info("Cleaning up action");
                     rimraf_1.sync(opts.workDirectory);
                     return [2 /*return*/];

--- a/src/action.ts
+++ b/src/action.ts
@@ -85,9 +85,7 @@ export async function runAction(opts: {
   core.endGroup();
 
   core.info(`Starting private action ${action.name}`);
-  core.startGroup(`${action.name}`);
   await exec.exec(`node ${join(actionPath, action.runs.main)}`);
-  core.endGroup();
 
   core.info(`Cleaning up action`);
   sync(opts.workDirectory);


### PR DESCRIPTION
Minor change to remove the group surrounding execution of the private action.  Nested groupings are not supported so if `endGroup()` is called from the private action it closes the wrong group.  Ideally Actions will eventually support nested groups and the ability to close groups by name, but it's not there yet.