### PR TITLE
feat: experimental partial-checkout feature for monorepos

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ This action loads and executes a private Action. This allows private actions to 
 
 **Optional** Directory containing the `action.yml` that you would like to execute in repo. If omitted, the root directory is assumed to be the location of `action.yml`.
 
+### **`pal-partial-checkout`**
+
+**Optional** Experimental: only clones the root files and `actionDirectory`, useful for monorepos.
+
 ---
 
 ## **Examples**
@@ -97,6 +101,19 @@ This action loads and executes a private Action. This allows private actions to 
     pal-repo-name: some-org/super-secret-action@v1
 - name: Get the previous output
   run: echo "The previous output was ${{ steps.output_example.outputs.<name of output> }}"
+```
+
+## Example usage for Large Monorepos (experimental)
+
+Limits the clone to root files and the `/action-directory/`
+
+```yaml
+- uses: invisionapp/private-action-loader@v3
+  with:
+    pal-repo-token: ${{ secrets.REPO_TOKEN }}
+    pal-repo-name: some-org/super-secret-action
+    pal-action-directory: src/super-secret-nested-action
+    pal-partial-checkout: true
 ```
 
 ---

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   pal-action-directory:
     description: 'The optional path to directory containing action.  Useful when multiple private actions are stored in the same repo'
     required: false
+  pal-partial-checkout:
+    description: 'Experimental: only clones the root files and actionDirectory, useful for monorepos.'
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/action.ts
+++ b/src/action.ts
@@ -36,6 +36,7 @@ export async function runAction(opts: {
   repoName: string;
   workDirectory: string;
   actionDirectory?: string;
+  partialCheckout?: string;
 }): Promise<void> {
   const [repo, sha] = opts.repoName.split('@');
 
@@ -44,25 +45,38 @@ export async function runAction(opts: {
 
   core.startGroup('Cloning private action');
   const repoUrl = `https://${opts.token}@github.com/${repo}.git`;
-  const cmd = ['git clone', repoUrl, opts.workDirectory].join(' ');
 
-  core.info(`Cleaning workDirectory`);
-  sync(opts.workDirectory);
+  if (['true', 'TRUE', 1].includes(opts.partialCheckout!)) {
+    if (!opts.actionDirectory) {
+      throw new Error('Experimental partial-checkout feature requires action-directory.');
+    }
+    await partialCheckout({
+      repoUrl,
+      sha,
+      workDirectory: opts.workDirectory,
+      actionDirectory: opts.actionDirectory!,
+    });
+  } else {
+    const cmd = ['git clone', repoUrl, opts.workDirectory].join(' ');
 
-  core.info(
-    `Cloning action from https://***TOKEN***@github.com/${repo}.git${sha ? ` (SHA: ${sha})` : ''}`
-  );
-  await exec.exec(cmd);
+    core.info(`Cleaning workDirectory`);
+    sync(opts.workDirectory);
+
+    core.info(
+      `Cloning action from https://***TOKEN***@github.com/${repo}.git${sha ? ` (SHA: ${sha})` : ''}`
+    );
+    await exec.exec(cmd);
+
+    if (sha) {
+      core.info(`Checking out ${sha}`);
+      await exec.exec(`git checkout ${sha}`, undefined, { cwd: opts.workDirectory });
+    }
+  }
 
   core.info('Remove github token from config');
   await exec.exec(`git remote set-url origin https://github.com/${repo}.git`, undefined, {
     cwd: opts.workDirectory,
   });
-
-  if (sha) {
-    core.info(`Checking out ${sha}`);
-    await exec.exec(`git checkout ${sha}`, undefined, { cwd: opts.workDirectory });
-  }
 
   // if actionDirectory specified, join with workDirectory (for use when multiple actions exist in same repo)
   // if actionDirectory not specified, use workDirectory (for repo with a single action at root)
@@ -89,4 +103,51 @@ export async function runAction(opts: {
 
   core.info(`Cleaning up action`);
   sync(opts.workDirectory);
+}
+
+/**
+ * Experimental feature to reduce network waste and
+ * time-to-action. Makes use of `git sparse-checkout`
+ * to _partially_ clone the repository, specifically,
+ * it only pulls the root, and actionDirectory files.
+ */
+async function partialCheckout({
+  repoUrl,
+  sha,
+  workDirectory,
+  actionDirectory,
+}: {
+  repoUrl: string;
+  sha: string;
+  workDirectory: string;
+  actionDirectory: string;
+}) {
+  core.info('Use experimental sparse-checkout feature');
+
+  // only clone the `.git` folder
+  const cmd = ['git clone', '--filter=blob:none', '--no-checkout', repoUrl, workDirectory].join(
+    ' '
+  );
+
+  core.info(`Cleaning workDirectory`);
+  sync(workDirectory);
+
+  core.info(`Partial cloning repository...`);
+  await exec.exec(cmd);
+
+  // this command will run `config core.sparsecheckout true` under the bonnet
+  // ensuring the root files will be pull later (--cone)
+  core.info(`Enabling sparse-checkout`);
+  await exec.exec(`git sparse-checkout init --cone`, undefined, { cwd: workDirectory });
+
+  if (sha) {
+    core.info(`Checking out ${sha}`);
+    await exec.exec(`git checkout ${sha}`, undefined, { cwd: workDirectory });
+  } else {
+    // force git to re-evaluate tree after sparse-checkout init
+    await exec.exec(`git read-tree -mu HEAD`, undefined, { cwd: workDirectory });
+  }
+
+  core.info(`Pulling actionDirectory ${actionDirectory}`);
+  await exec.exec(`git sparse-checkout set ${actionDirectory}`, undefined, { cwd: workDirectory });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { runAction } from './action';
 const token = core.getInput('pal-repo-token', { required: true });
 const repoName = core.getInput('pal-repo-name', { required: true });
 const actionDirectory = core.getInput('pal-action-directory', { required: false });
+const partialCheckout = core.getInput('pal-partial-checkout', { required: false });
 const workDirectory = './.private-action';
 
 runAction({
@@ -11,6 +12,7 @@ runAction({
   repoName,
   actionDirectory,
   workDirectory,
+  partialCheckout
 })
   .then(() => {
     core.info('Action completed successfully');


### PR DESCRIPTION
We noticed significantly load times as this action cloned our entire monorepository to run the nested action. This exposes a new option which limits cloning just to the `pal-action-directory` with the help of `git sparse-checkout`.